### PR TITLE
Config input update v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "configcat-feature-flags",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "configcat-feature-flags",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"configcat-publicapi-node-client": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "configcat-feature-flags",
 	"displayName": "ConfigCat Feature Flags",
 	"description": "ConfigCat Visual Studio Code extension to manage feature flags from Visual Studio Code.",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"publisher": "ConfigCat",
 	"repository": "https://github.com/configcat/vscode-extension-configcat",
 	"preview": false,

--- a/src/inputs/config-input.ts
+++ b/src/inputs/config-input.ts
@@ -41,7 +41,7 @@ export class ConfigInput {
     static async configVersionInput(): Promise<EvaluationVersion> {
         
         const pick = await vscode.window.showQuickPick(
-            [{label:"V1"} ,{label: "V2", description: "(Beta)"} ],
+            [{label: "V2"}, {label:"V1", description: "(Legacy)"} ],
             {
                 canPickMany: false,
                 placeHolder: 'Select the config version'


### PR DESCRIPTION
### Describe the purpose of your pull request

- Updated config input. V2 now is the default option

### Related issues (only if applicable)

[Trello ticket](https://trello.com/c/M5oqMYUF/313-vscode-integben-a-config-createnel-v2-legyen-a-default-m-vegyuk-le-a-beta-t-rola-es-legyen-a-v1-legacy)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
